### PR TITLE
Complétion de l'évolution de l'équipe

### DIFF
--- a/_posts/2019-11-07-dixieme-edition.md
+++ b/_posts/2019-11-07-dixieme-edition.md
@@ -12,11 +12,16 @@ Eh bien, l’équipe ne sait pas. Elle n’est pas sure qu’il y aura une nouve
 
 ## Évolution de l’équipe
 
- * En **2016**, l’équipe comportait 8 personnes, 5 anciens, 3 nouveaux.
- * En **2017**, l’équipe comportait 8 personnes, 6 anciens, 2 nouveaux.
- * En **2018**, l’équipe comportait 7 personnes, 4 anciens, 3 nouveaux.
- * En **2019**, l’équipe comportait 4 personnes, 2 anciens, 2 nouveaux.
- * En **2020**, l’équipe comporte 3 personnes, 3 anciens
+ * En **2011**, l’équipe comportait 15 personnes, 15 nouvelles.
+ * En **2012**, l’équipe comportait 12 personnes, 12 anciennes.
+ * En **2013**, l’équipe comportait 9 personnes, 9 anciennes.
+ * En **2014**, l’équipe comportait 3 personnes et demi, 4 anciennes.
+ * En **2015**, l’équipe comportait 5 personnes, 3 anciennes, 2 nouvelles.
+ * En **2016**, l’équipe comportait 8 personnes, 5 anciennes, 3 nouvelles.
+ * En **2017**, l’équipe comportait 8 personnes, 6 anciennes, 2 nouvelles.
+ * En **2018**, l’équipe comportait 7 personnes, 4 anciennes, 3 nouvelles.
+ * En **2019**, l’équipe comportait 4 personnes, 2 anciennes, 2 nouvelles.
+ * En **2020**, l’équipe comporte 3 personnes, 3 anciennes
 
 S'il y a eu une certaine stabilité durant plusieurs années, pendant laquelle l'équipe était tenue par les fondateurs, il y a eu ensuite un renouvellement important en 2018. 
 


### PR DESCRIPTION
Les personnes sont dans le "désordre" — j'ai reconstitué la liste à partir d'archives mail issues d'un BaseCamp et d'un Google Group utilisés dans les premières années.

2011 (Nismes) : 
- Goulven Champenois
- Mathieu Agopian
- Nathalie Rosenberg
- Rudy Rigot
- Frank Taillandier
- Thomas Parisot
- Loic Mathaud
- Yann Madeleine
- Sébastien Desbenoit
- Jean-Michel Armand
- Aymeric de Martin de Vivies
- Marie Alhomme
- Nicolas Perriault
- David Larlet
- Thibault Jouannic

2012 (Toulouse) :
- Goulven Champenois
- Mathieu Agopian
- Nathalie Rosenberg
- Rudy Rigot
- Frank Taillandier
- Thomas Parisot
- Loic Mathaud
- Yann Madeleine
- Sébastien Desbenoit
- Jean-Michel Armand
- Aymeric de Martin de Vivies
- Marie Alhomme

2013 (Avignon) :
- Goulven Champenois
- Nathalie Rosenberg
- Rudy Rigot
- Frank Taillandier
- Thomas Parisot
- Loic Mathaud
- Yann Madeleine
- Sébastien Desbenoit
- Marie Alhomme

2014 (Toulouse) :
- Nathalie Rosenberg
- Frank Taillandier
- Thomas Parisot
- (Loic Mathaud en "congé paternité")

2015 (Montpellier) :
- Nathalie Rosenberg
- Frank Taillandier
- Thomas Parisot
- Amanda Martinez
- Erick Gardin
- Loic Mathaud